### PR TITLE
Build for scala 2.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,10 @@ scalacOptions ++= Seq(
 )
 
 crossScalaVersions := Seq("2.11.8", "2.12.4")
-scalaVersion := "2.12.4"
+scalaVersion := "2.13.0"
 organization := "com.ajjpj.simple-akka-downing"
 
 version      := "0.9.3"
-
 
 lazy val `simple-akka-downing` = (project in file("."))
   .enablePlugins(MultiJvmPlugin)


### PR DESCRIPTION
I would like to use this with akka `2.5.23` and scala `2.13.0`, which currently does not work, because of this:

```
java.lang.NoClassDefFoundError: scala/Serializable
    	at com.ajjpj.simpleakkadowning.SimpleAkkaDowningProvider.<init>(SimpleAkkaDowningProvider.scala:23)
```